### PR TITLE
feat: add todo filters and summary

### DIFF
--- a/.cursor/rules/deployment-guide.mdc
+++ b/.cursor/rules/deployment-guide.mdc
@@ -1,0 +1,316 @@
+---
+description: "Vibe Coding Starter デプロイメントガイド（Vercel + 本番環境）"
+globs: .vercel/**,vercel.json,package.json,.env*
+alwaysApply: false
+---
+
+# 🚀 Vibe Coding Starter デプロイメントガイド
+
+このガイドでは、Vibe Coding StarterプロジェクトをVercelを使って本番環境にデプロイする手順を説明します。
+
+## 📋 前提条件
+
+- ✅ プロジェクトがGitHubにプッシュ済み
+- ✅ Supabaseプロジェクトが作成済み
+- ✅ ローカルで動作確認済み
+- ✅ `.env.local`で環境変数設定済み
+
+## 🌐 Vercelデプロイ手順
+
+### ステップ1: Vercel CLIのインストール
+
+```bash
+# Vercel CLIをグローバルにインストール
+npm install -g vercel@latest
+
+# バージョン確認
+vercel --version
+```
+
+### ステップ2: Vercelログイン
+
+```bash
+# GitHubアカウントでログイン
+vercel login
+# ブラウザが開くのでGitHubで認証
+```
+
+### ステップ3: プロジェクトデプロイ
+
+```bash
+# プロジェクトルートで実行
+vercel --prod
+
+# 設定質問への回答例：
+# ? Set up and deploy? → yes
+# ? Which scope? → あなたのアカウントを選択
+# ? Link to existing project? → no（新規の場合）
+# ? Project name? → vibe-coding-starter
+# ? In which directory is your code located? → ./
+```
+
+### ステップ4: 自動検出される設定
+
+Vercelが自動的に以下を検出します：
+
+```yaml
+Framework: Vite
+Build Command: vite build
+Development Command: vite --port $PORT
+Install Command: npm install
+Output Directory: dist
+```
+
+## 🔧 環境変数の設定（重要！）
+
+デプロイ後、Vercelダッシュボードで環境変数を設定する必要があります。
+
+### Vercelダッシュボードでの設定
+
+1. **Vercel Dashboard** → プロジェクト選択
+2. **Settings** → **Environment Variables**
+3. 以下の変数を追加：
+
+```bash
+# Supabase設定
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key-here
+
+# アプリ設定
+VITE_APP_NAME=Vibe Coding スターター
+```
+
+### 環境変数の設定手順
+
+```bash
+# 1. 本番用の値を準備
+# Supabase Dashboard > Settings > API から取得
+
+# 2. Vercelで設定
+Name: VITE_SUPABASE_URL
+Value: https://your-actual-project.supabase.co
+Environment: Production, Preview, Development
+
+Name: VITE_SUPABASE_ANON_KEY  
+Value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Environment: Production, Preview, Development
+
+Name: VITE_APP_NAME
+Value: Vibe Coding スターター
+Environment: Production, Preview, Development
+```
+
+## 🔄 継続的デプロイの設定
+
+### GitHubとの連携
+
+Vercelプロジェクトは自動的にGitHubリポジトリと連携されます：
+
+- **mainブランチ** → 本番環境に自動デプロイ
+- **その他ブランチ** → プレビュー環境に自動デプロイ
+- **Pull Request** → プレビューURLが自動生成
+
+### 自動デプロイの確認
+
+```bash
+# 変更をプッシュして自動デプロイをテスト
+git add .
+git commit -m "test: verify auto deployment"
+git push origin main
+
+# Vercelが自動的にデプロイを開始
+```
+
+## 📊 デプロイ後の確認事項
+
+### 動作確認チェックリスト
+
+- [ ] サイトが正常に表示される
+- [ ] ログインフォームが表示される
+- [ ] Supabase接続エラーがない
+- [ ] 認証機能が動作する
+- [ ] Todo機能が正常に動作する
+- [ ] レスポンシブデザインが適切
+
+### トラブルシューティング
+
+#### 1. 環境変数エラー
+```bash
+# エラー例: "Environment variable not defined"
+# 解決策: Vercelダッシュボードで環境変数を再確認
+```
+
+#### 2. Supabase接続エラー
+```bash
+# エラー例: "Failed to fetch todos"
+# 解決策: 
+# 1. VITE_SUPABASE_URLが正しいか確認
+# 2. VITE_SUPABASE_ANON_KEYが正しいか確認
+# 3. Supabaseプロジェクトがアクティブか確認
+```
+
+#### 3. ビルドエラー
+```bash
+# エラー例: "Build failed"
+# 解決策:
+# 1. ローカルで npm run build を実行して確認
+# 2. TypeScriptエラーを修正
+# 3. 再デプロイ
+```
+
+## 🎯 Vercel設定ファイル（オプション）
+
+プロジェクトルートに `vercel.json` を作成してカスタム設定が可能：
+
+```json
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "devCommand": "npm run dev",
+  "framework": "vite",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}
+```
+
+## 🌍 カスタムドメインの設定
+
+### 独自ドメインの追加
+
+1. **Vercel Dashboard** → **Domains**
+2. **Add Domain** をクリック
+3. ドメイン名を入力（例：`your-domain.com`）
+4. DNSレコードを設定：
+
+```bash
+# CNAMEレコード
+Type: CNAME
+Name: www
+Value: cname.vercel-dns.com
+
+# Aレコード（Apex domain）
+Type: A
+Name: @
+Value: 76.76.19.61
+```
+
+## 📈 パフォーマンス最適化
+
+### Vercel Analytics（オプション）
+
+```bash
+# Vercel Analyticsパッケージのインストール
+npm install @vercel/analytics
+
+# React統合
+import { Analytics } from '@vercel/analytics/react';
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <Component {...pageProps} />
+      <Analytics />
+    </>
+  );
+}
+```
+
+### 最適化のベストプラクティス
+
+1. **画像最適化**: Vercel Image Optimization使用
+2. **キャッシュ設定**: 静的アセットの適切なキャッシュ
+3. **バンドルサイズ**: Viteの自動最適化を活用
+
+## 🔐 セキュリティ設定
+
+### 環境変数の保護
+
+- ✅ `VITE_`プレフィックスでクライアント公開変数
+- ❌ シークレットキーは`VITE_`を使わない
+- ✅ 本番・プレビュー・開発環境別設定
+
+### セキュリティヘッダー
+
+`vercel.json`でセキュリティヘッダーを設定：
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## 📚 メンテナンスとモニタリング
+
+### 定期的な確認事項
+
+- [ ] デプロイ状況の確認
+- [ ] エラーログの監視
+- [ ] パフォーマンスメトリクスの確認
+- [ ] セキュリティアップデートの適用
+
+### 有用なVercelコマンド
+
+```bash
+# プロジェクト情報確認
+vercel ls
+
+# ログ確認
+vercel logs
+
+# 環境変数確認
+vercel env ls
+
+# ドメイン確認
+vercel domains ls
+
+# プロジェクト削除（注意）
+vercel remove project-name
+```
+
+## 🆘 サポートとリソース
+
+### 公式ドキュメント
+
+- [Vercel Documentation](https://vercel.com/docs)
+- [Vite Deployment Guide](https://vitejs.dev/guide/static-deploy.html#vercel)
+- [Supabase Documentation](https://supabase.com/docs)
+
+### よくある質問
+
+**Q: デプロイが失敗する**
+A: ローカルで`npm run build`を実行してエラーを確認
+
+**Q: 環境変数が反映されない**
+A: Vercelダッシュボードで設定後、再デプロイが必要
+
+**Q: カスタムドメインが設定できない**
+A: DNSの伝播には最大48時間かかる場合があります
+
+## 💡 開発効率化のコツ
+
+1. **プレビューデプロイ活用**: PR作成で自動プレビュー
+2. **ローカル開発**: `vercel dev`でローカル環境をVercel環境に近づける
+3. **段階的デプロイ**: 重要な変更は段階的にリリース
+
+---
+
+このガイドに従えば、Vibe Coding Starterプロジェクトを確実にVercelでホスティングできます。問題が発生した場合は、トラブルシューティングセクションを参照してください。

--- a/.cursor/rules/deployment-guide.mdc
+++ b/.cursor/rules/deployment-guide.mdc
@@ -1,9 +1,7 @@
 ---
 description: "Vibe Coding Starter デプロイメントガイド（Vercel + 本番環境）"
-globs: .vercel/**,vercel.json,package.json,.env*
 alwaysApply: false
 ---
-
 # 🚀 Vibe Coding Starter デプロイメントガイド
 
 このガイドでは、Vibe Coding StarterプロジェクトをVercelを使って本番環境にデプロイする手順を説明します。

--- a/.cursor/rules/environment-management.mdc
+++ b/.cursor/rules/environment-management.mdc
@@ -1,9 +1,7 @@
 ---
 description: "環境変数とプロジェクト設定管理ルール"
-globs: .env*,src/shared/lib/env.ts,vite-env.d.ts,README.md
 alwaysApply: false
 ---
-
 # 環境変数とプロジェクト設定管理ルール
 
 ## 基本原則

--- a/.cursor/rules/setup-guide.mdc
+++ b/.cursor/rules/setup-guide.mdc
@@ -1,9 +1,7 @@
 ---
 description: "Vibe Coding Starter 初期セットアップガイド（つまずき防止）"
-globs: .env*,README.md,package.json
 alwaysApply: false
 ---
-
 # 🚀 Vibe Coding Starter セットアップガイド
 
 このガイドは初心者がつまずかないように、段階的なセットアップ手順を提供します。
@@ -146,7 +144,31 @@ npm run typecheck
 1. **Feature追加の練習**: todo機能を参考に新機能を実装
 2. **UI改善**: shared/ui コンポーネントをカスタマイズ
 3. **データベース拡張**: 新しいテーブルを追加
-4. **デプロイ**: Vercel や Netlify でホスティング
+4. **デプロイ**: Vercelでホスティング（詳細は `.cursor/rules/deployment-guide.mdc` 参照）
+
+## 🌐 本番デプロイ（Vercel推奨）
+
+### クイックデプロイ
+```bash
+# Vercel CLIインストール
+npm install -g vercel@latest
+
+# ログイン
+vercel login
+
+# デプロイ
+vercel --prod
+```
+
+### 重要：環境変数設定
+デプロイ後、Vercelダッシュボードで以下を設定：
+```
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key-here
+VITE_APP_NAME=Vibe Coding スターター
+```
+
+詳細な手順は **`.cursor/rules/deployment-guide.mdc`** を参照してください。
 
 ## 💡 開発のコツ
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ build
 dist
 
 .specstory/
+.vercel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,47 +1,47 @@
-# 🤝 Contributing to Vibe Coding Starter
+# 🤝 Vibe Coding Starter への貢献
 
-This guide helps both **human developers** and **AI assistants** contribute to this project effectively.
+このガイドは、**人間の開発者**と**AIアシスタント**の両方がこのプロジェクトに効果的に貢献するためのものです。
 
-## 🎯 Core Principles
+## 🎯 基本原則
 
-1. **Feature-first organization** - Group by features, not file types
-2. **Type safety** - TypeScript strict mode, no `any` allowed
-3. **Consistency** - Follow established patterns
-4. **Simplicity** - Prefer simple, readable solutions
-5. **AI-friendly** - Clear structure that AI can understand and extend
+1. **Feature-first組織** - ファイルタイプではなく機能でグループ化
+2. **型安全性** - TypeScript strict mode、`any`は禁止
+3. **一貫性** - 確立されたパターンに従う
+4. **シンプルさ** - シンプルで読みやすいソリューションを優先
+5. **AI対応** - AIが理解・拡張できる明確な構造
 
-## 📁 Project Structure Rules
+## 📁 プロジェクト構造ルール
 
-### Directory Organization
+### ディレクトリ構成
 
 ```
 src/
-  app/                 # ✅ Pages and routing only
-  features/            # ✅ Feature-specific code (main workspace)
+  app/                 # ✅ ページとルーティングのみ
+  features/            # ✅ 機能固有のコード（メインワークスペース）
     <feature-name>/
-      components/      # UI components for this feature
-      api.ts          # Database/API calls (Supabase)
-      hooks.ts        # React Query hooks
-      schema.ts       # Validation schemas (zod)
-      types.ts        # TypeScript type definitions
-      index.ts        # Feature exports
-  shared/             # ✅ Shared utilities and components
-    ui/               # Reusable UI components
-    lib/              # Utilities and configuration
-    config.ts         # Global constants (NO hardcoding elsewhere)
-    types/            # Shared type definitions
+      components/      # この機能のUIコンポーネント
+      api.ts          # データベース/API呼び出し（Supabase）
+      hooks.ts        # React Queryフック
+      schema.ts       # バリデーションスキーマ（zod）
+      types.ts        # TypeScript型定義
+      index.ts        # 機能のエクスポート
+  shared/             # ✅ 共有ユーティリティとコンポーネント
+    ui/               # 再利用可能なUIコンポーネント
+    lib/              # ユーティリティと設定
+    config.ts         # グローバル定数（他の場所でハードコーディング禁止）
+    types/            # 共有型定義
 ```
 
-### ✅ What Goes Where
+### ✅ 何をどこに置くか
 
-| File Type     | Location                | Purpose                                     |
-| ------------- | ----------------------- | ------------------------------------------- |
-| Pages         | `src/app/`              | Route components, layout, navigation        |
-| Feature logic | `src/features/*/`       | Business logic, feature-specific components |
-| Reusable UI   | `src/shared/ui/`        | Button, Input, Card, etc.                   |
-| Configuration | `src/shared/lib/env.ts` | Environment variables (zod-validated)       |
-| Constants     | `src/shared/config.ts`  | Global constants and settings               |
-| Types         | `src/shared/types/`     | Shared type definitions                     |
+| ファイルタイプ | 場所                    | 目的                                             |
+| -------------- | ----------------------- | ------------------------------------------------ |
+| ページ         | `src/app/`              | ルートコンポーネント、レイアウト、ナビゲーション |
+| 機能ロジック   | `src/features/*/`       | ビジネスロジック、機能固有のコンポーネント       |
+| 再利用可能UI   | `src/shared/ui/`        | Button、Input、Cardなど                          |
+| 設定           | `src/shared/lib/env.ts` | 環境変数（zod検証済み）                          |
+| 定数           | `src/shared/config.ts`  | グローバル定数と設定                             |
+| 型             | `src/shared/types/`     | 共有型定義                                       |
 
 ## 🔒 Strict Rules (Never Break These)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,18 +43,18 @@ src/
 | 定数           | `src/shared/config.ts`  | グローバル定数と設定                             |
 | 型             | `src/shared/types/`     | 共有型定義                                       |
 
-## 🔒 Strict Rules (Never Break These)
+## 🔒 厳格なルール（絶対に破ってはいけない）
 
-### 1. No Hardcoding
+### 1. ハードコーディング禁止
 
-❌ **Wrong:**
+❌ **間違い:**
 
 ```typescript
 const apiUrl = 'https://api.example.com';
 const pageSize = 20;
 ```
 
-✅ **Correct:**
+✅ **正しい:**
 
 ```typescript
 import { env } from '@/shared/lib/env';
@@ -64,9 +64,9 @@ const apiUrl = env.VITE_API_URL;
 const pageSize = ui.defaultPageSize;
 ```
 
-### 2. No `any` Type
+### 2. `any`型の禁止
 
-❌ **Wrong:**
+❌ **間違い:**
 
 ```typescript
 function handleData(data: any) {
@@ -74,7 +74,7 @@ function handleData(data: any) {
 }
 ```
 
-✅ **Correct:**
+✅ **正しい:**
 
 ```typescript
 import { z } from 'zod';
@@ -89,41 +89,41 @@ function handleData(data: unknown) {
 }
 ```
 
-### 3. Database Access Through `api.ts`
+### 3. データベースアクセスは`api.ts`経由
 
-❌ **Wrong (in a component):**
+❌ **間違い（コンポーネント内で）:**
 
 ```typescript
 const { data } = await supabase.from('todos').select('*');
 ```
 
-✅ **Correct:**
+✅ **正しい:**
 
 ```typescript
-// In features/todo/api.ts
+// features/todo/api.ts 内
 export async function listTodos() {
   const { data, error } = await supabase.from('todos').select('*');
   if (error) throw error;
   return data;
 }
 
-// In component
+// コンポーネント内
 import { useTodos } from './hooks';
 const { data } = useTodos();
 ```
 
-### 4. Validation with Zod
+### 4. Zodによるバリデーション
 
-❌ **Wrong:**
+❌ **間違い:**
 
 ```typescript
 function createTodo(title: string) {
-  // Hope title is valid...
+  // titleが有効であることを祈る...
   return api.create({ title });
 }
 ```
 
-✅ **Correct:**
+✅ **正しい:**
 
 ```typescript
 import { todoInputSchema } from './schema';
@@ -134,19 +134,19 @@ function createTodo(input: unknown) {
 }
 ```
 
-## 🎨 Coding Standards
+## 🎨 コーディング規約
 
-### TypeScript Configuration
+### TypeScript設定
 
-- Use **strict mode** - `"strict": true`
-- Enable additional strict checks:
+- **strict mode**を使用 - `"strict": true`
+- 追加の厳格チェックを有効化:
   - `"exactOptionalPropertyTypes": true`
   - `"noUncheckedIndexedAccess": true`
   - `"useUnknownInCatchVariables": true`
 
-### Import Organization
+### インポート組織
 
-Imports should be organized in this order (enforced by ESLint):
+インポートは以下の順序で整理する（ESLintで強制）:
 
 ```typescript
 // 1. Node modules
@@ -161,35 +161,35 @@ import { useTodos } from './hooks';
 import './styles.css';
 ```
 
-### Naming Conventions
+### 命名規約
 
-| Type                | Convention       | Example                    |
+| タイプ              | 規約             | 例                         |
 | ------------------- | ---------------- | -------------------------- |
-| Files               | kebab-case       | `todo-form.tsx`            |
-| Components          | PascalCase       | `TodoForm`                 |
-| Variables/Functions | camelCase        | `fetchTodos`, `isLoading`  |
-| Constants           | UPPER_SNAKE_CASE | `DEFAULT_PAGE_SIZE`        |
-| Types/Interfaces    | PascalCase       | `TodoInput`, `ApiResponse` |
+| ファイル            | kebab-case       | `todo-form.tsx`            |
+| コンポーネント      | PascalCase       | `TodoForm`                 |
+| 変数/関数           | camelCase        | `fetchTodos`, `isLoading`  |
+| 定数                | UPPER_SNAKE_CASE | `DEFAULT_PAGE_SIZE`        |
+| 型/インターフェース | PascalCase       | `TodoInput`, `ApiResponse` |
 
-## 🚀 Adding New Features
+## 🚀 新機能の追加
 
-### Step-by-Step Process
+### ステップバイステップのプロセス
 
-1. **Create feature directory:**
+1. **機能ディレクトリの作成:**
 
    ```bash
    mkdir src/features/my-feature
    cd src/features/my-feature
    ```
 
-2. **Create core files:**
+2. **コアファイルの作成:**
 
    ```bash
    touch api.ts hooks.ts schema.ts types.ts index.ts
    mkdir components
    ```
 
-3. **Define types first (`types.ts`):**
+3. **最初に型を定義（`types.ts`）:**
 
    ```typescript
    export interface MyFeatureItem {
@@ -199,7 +199,7 @@ import './styles.css';
    }
    ```
 
-4. **Create validation schemas (`schema.ts`):**
+4. **バリデーションスキーマの作成（`schema.ts`）:**
 
    ```typescript
    import { z } from 'zod';
@@ -211,7 +211,7 @@ import './styles.css';
    export type MyFeatureInput = z.infer<typeof myFeatureInputSchema>;
    ```
 
-5. **Implement API calls (`api.ts`):**
+5. **API呼び出しの実装（`api.ts`）:**
 
    ```typescript
    import { supabase } from '@/shared/lib/supabase';
@@ -224,7 +224,7 @@ import './styles.css';
    }
    ```
 
-6. **Create React Query hooks (`hooks.ts`):**
+6. **React Queryフックの作成（`hooks.ts`）:**
 
    ```typescript
    import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';

--- a/README.md
+++ b/README.md
@@ -1,88 +1,88 @@
 # 🚀 Vibe Coding Starter
 
-A beginner-friendly React + TypeScript template designed for **Vibe Coding** - the AI-assisted programming style where you describe what you want and let AI help you build it.
+**Vibe Coding** スタイル（AIが開発を支援するプログラミング手法）に最適化された、初心者向けの React + TypeScript テンプレートです。作りたいものを説明するだけで、AIがその実装をサポートします。
 
-## ✨ What is Vibe Coding?
+## ✨ Vibe Coding とは？
 
-Vibe Coding is a development approach where you focus on describing the "vibe" or feeling of what you want to build, and use AI to help implement it. This starter template provides a solid foundation that's both beginner-friendly and AI-friendly.
+Vibe Coding とは、作りたいものの「雰囲気」や「感覚」を言葉で表現し、AIを活用して実装を進める開発手法です。このスターターテンプレートは、初心者でもAIでも扱いやすい堅固な基盤を提供します。
 
-## 🏗️ Architecture: Feature-first Lite
+## 🏗️ アーキテクチャ：Feature-first Lite
 
-This project uses a simplified "Feature-first" architecture that's perfect for learning:
+このプロジェクトは学習に最適化されたシンプルな「Feature-first」アーキテクチャを採用しています：
 
 ```
 src/
-  app/           # 📄 Pages and routing
-  features/      # 🎯 Features (the main workspace)
-    todo/        # Example: Todo feature
-      components/    # UI components for this feature
-      api.ts        # Database calls (Supabase)
-      hooks.ts      # React Query hooks
-      schema.ts     # Validation (zod)
-      types.ts      # TypeScript types
-  shared/        # 🔧 Shared utilities
-    ui/          # Reusable UI components
-    lib/         # Configuration and utilities
-    config.ts    # Global constants
+  app/           # 📄 ページとルーティング
+  features/      # 🎯 機能（メインワークスペース）
+    todo/        # 例：Todo機能
+      components/    # この機能専用のUIコンポーネント
+      api.ts        # データベース呼び出し（Supabase）
+      hooks.ts      # React Query フック
+      schema.ts     # バリデーション（zod）
+      types.ts      # TypeScript型定義
+  shared/        # 🔧 共通ユーティリティ
+    ui/          # 再利用可能なUIコンポーネント
+    lib/         # 設定とユーティリティ
+    config.ts    # グローバル定数
 ```
 
-### 🎯 Simple Rules
+### 🎯 シンプルなルール
 
-1. **Pages go in `app/`** - routing and layout
-2. **Features go in `features/*`** - all business logic
-3. **Shared stuff goes in `shared/`** - reusable components and utilities
-4. **No hardcoding** - use `shared/lib/env.ts` for environment variables, `shared/config.ts` for constants
+1. **ページは `app/` に配置** - ルーティングとレイアウト
+2. **機能は `features/*` に配置** - すべてのビジネスロジック
+3. **共通部分は `shared/` に配置** - 再利用可能なコンポーネントとユーティリティ
+4. **ハードコーディング禁止** - 環境変数は `shared/lib/env.ts`、定数は `shared/config.ts` を使用
 
-## 🛠️ Tech Stack
+## 🛠️ 技術スタック
 
 - **React 18** + **TypeScript** (strict mode)
-- **Vite** - Fast development server
-- **Tailwind CSS** - Utility-first styling
-- **Supabase** - Backend as a Service (database, auth, real-time)
-- **React Query** - Data fetching and caching
-- **React Hook Form** + **Zod** - Form handling and validation
-- **React Router** - Client-side routing
-- **ESLint** + **Prettier** - Code quality and formatting
+- **Vite** - 高速開発サーバー
+- **Tailwind CSS** - ユーティリティファーストCSS
+- **Supabase** - Backend as a Service（データベース、認証、リアルタイム）
+- **React Query** - データフェッチとキャッシュ
+- **React Hook Form** + **Zod** - フォーム処理とバリデーション
+- **React Router** - クライアントサイドルーティング
+- **ESLint** + **Prettier** - コード品質とフォーマット
 
-## 🚀 Quick Start
+## 🚀 クイックスタート
 
-### 1. Install Dependencies
+### 1. 依存関係のインストール
 
 ```bash
 npm install
-# or
+# または
 pnpm install
 ```
 
-### 2. Set Up Environment
+### 2. 環境設定
 
-Copy the example environment file:
+サンプル環境ファイルをコピー：
 
 ```bash
 cp env.example .env.local
 ```
 
-Edit `.env.local` with your Supabase credentials:
+`.env.local` を編集してSupabaseの認証情報を設定：
 
 ```env
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
 ```
 
-### 3. Start Development
+### 3. 開発開始
 
 ```bash
 npm run dev
 ```
 
-Visit [http://localhost:5173](http://localhost:5173) to see your app!
+[http://localhost:5173](http://localhost:5173) にアクセスしてアプリを確認！
 
-## 📊 Database Setup (Supabase)
+## 📊 データベースセットアップ（Supabase）
 
-### Create the todos table
+### todosテーブルの作成
 
 ```sql
--- Create todos table
+-- todosテーブルを作成
 create table public.todos (
   id uuid default gen_random_uuid() primary key,
   title text not null,
@@ -92,10 +92,10 @@ create table public.todos (
   updated_at timestamp with time zone default timezone('utc'::text, now()) not null
 );
 
--- Enable Row Level Security
+-- Row Level Securityを有効化
 alter table public.todos enable row level security;
 
--- Create policies
+-- ポリシーを作成
 create policy "Users can read their own todos"
   on public.todos for select
   using (auth.uid() = user_id);
@@ -113,145 +113,145 @@ create policy "Users can delete their own todos"
   using (auth.uid() = user_id);
 ```
 
-### Generate TypeScript types
+### TypeScript型の生成
 
 ```bash
 npx supabase gen types typescript --project-id YOUR_PROJECT_ID --schema public > src/shared/types/supabase.ts
 ```
 
-## 🎨 For Vibe Coding Beginners
+## 🎨 Vibe Coding 初心者向け
 
-### Where to Start Coding
+### コーディングを始める場所
 
-1. **Add new pages**: Create files in `src/app/`
-2. **Add new features**: Create folders in `src/features/`
-3. **Modify the todo example**: Look in `src/features/todo/`
+1. **新しいページを追加**: `src/app/` にファイルを作成
+2. **新しい機能を追加**: `src/features/` にフォルダを作成
+3. **todoサンプルを変更**: `src/features/todo/` を参照
 
-### AI Prompting Tips
+### AI プロンプトのコツ
 
-When working with AI, be specific about the structure:
+AIと作業する際は、構造を具体的に指定しましょう：
 
-✅ **Good prompts:**
+✅ **良いプロンプト例:**
 
-- "Add a new component in `src/features/todo/components/` that shows todo statistics"
-- "Create a new feature in `src/features/auth/` for user login with Supabase"
-- "Add a filter dropdown to the TodoList component"
+- "`src/features/todo/components/` にtodo統計を表示する新しいコンポーネントを追加"
+- "`src/features/auth/` にSupabaseを使ったユーザーログイン機能を作成"
+- "TodoListコンポーネントにフィルタードロップダウンを追加"
 
-❌ **Avoid vague prompts:**
+❌ **避けるべき曖昧なプロンプト:**
 
-- "Make the app better"
-- "Add some features"
-- "Fix everything"
+- "アプリを良くして"
+- "何か機能を追加して"
+- "全部修正して"
 
-### File Organization Rules
+### ファイル組織ルール
 
-- **One feature = one folder** in `src/features/`
-- **Database calls** go in `api.ts`
-- **React Query hooks** go in `hooks.ts`
-- **Validation schemas** go in `schema.ts`
-- **UI components** go in `components/`
+- **1つの機能 = 1つのフォルダ** を `src/features/` に
+- **データベース呼び出し** は `api.ts` に
+- **React Query フック** は `hooks.ts` に
+- **バリデーションスキーマ** は `schema.ts` に
+- **UIコンポーネント** は `components/` に
 
-## 🧪 Available Scripts
+## 🧪 利用可能なスクリプト
 
 ```bash
-# Development
-npm run dev          # Start dev server
-npm run build        # Build for production
-npm run preview      # Preview production build
+# 開発
+npm run dev          # 開発サーバーを起動
+npm run build        # 本番用にビルド
+npm run preview      # 本番ビルドをプレビュー
 
-# Code Quality
-npm run lint         # Check for linting errors
-npm run lint:fix     # Fix linting errors
-npm run typecheck    # Check TypeScript types
-npm run format       # Format code with Prettier
+# コード品質
+npm run lint         # lintエラーをチェック
+npm run lint:fix     # lintエラーを修正
+npm run typecheck    # TypeScript型をチェック
+npm run format       # Prettierでコードをフォーマット
 ```
 
-## 🛡️ Code Quality & Safety
+## 🛡️ コード品質と安全性
 
-This template includes several safety nets:
+このテンプレートには複数の安全機能が含まれています：
 
-- **TypeScript strict mode** - Catches type errors
-- **ESLint with `no-explicit-any`** - Prevents loose typing
-- **Zod validation** - Runtime type checking
-- **Prettier** - Consistent code formatting
-- **Import organization** - Clean, sorted imports
+- **TypeScript strict mode** - 型エラーをキャッチ
+- **ESLint with `no-explicit-any`** - 緩い型付けを防止
+- **Zod validation** - 実行時型チェック
+- **Prettier** - 一貫したコードフォーマット
+- **Import organization** - 整理されたインポート順序
 
-## 📚 Learning Path
+## 📚 学習パス
 
-### Level 1: Basic Usage (Start Here!)
+### レベル1: 基本的な使用方法（ここから始めよう！）
 
-- [ ] Run the app and explore the todo feature
-- [ ] Add a new todo and see it in the database
-- [ ] Modify the TodoForm component
-- [ ] Change some Tailwind styles
+- [ ] アプリを実行してtodo機能を探索する
+- [ ] 新しいtodoを追加してデータベースで確認する
+- [ ] TodoFormコンポーネントを変更する
+- [ ] Tailwindスタイルを変更する
 
-### Level 2: Adding Features
+### レベル2: 機能追加
 
-- [ ] Create a new feature (e.g., notes, habits)
-- [ ] Add user authentication
-- [ ] Create custom UI components in `shared/ui/`
-- [ ] Add form validation with zod
+- [ ] 新しい機能を作成する（例：メモ、習慣）
+- [ ] ユーザー認証を追加する
+- [ ] `shared/ui/` にカスタムUIコンポーネントを作成する
+- [ ] zodでフォームバリデーションを追加する
 
-### Level 3: Advanced Patterns
+### レベル3: 高度なパターン
 
-- [ ] Add real-time updates with Supabase
-- [ ] Implement optimistic updates
-- [ ] Add error boundaries
-- [ ] Set up testing with Vitest
+- [ ] Supabaseでリアルタイム更新を追加する
+- [ ] オプティミスティック更新を実装する
+- [ ] エラーバウンダリを追加する
+- [ ] Vitestでテストを設定する
 
-## 🔧 Customization
+## 🔧 カスタマイズ
 
-### Adding a New Feature
+### 新機能の追加
 
-1. Create a new folder in `src/features/`
-2. Add the standard files: `api.ts`, `hooks.ts`, `schema.ts`, `types.ts`, `components/`
-3. Export everything from an `index.ts` file
-4. Create a page in `src/app/` that uses your feature
+1. `src/features/` に新しいフォルダを作成
+2. 標準ファイルを追加：`api.ts`、`hooks.ts`、`schema.ts`、`types.ts`、`components/`
+3. `index.ts` ファイルからすべてをエクスポート
+4. その機能を使用するページを `src/app/` に作成
 
-### Modifying Styles
+### スタイルの変更
 
-- Edit `src/styles/globals.css` for global styles
-- Modify Tailwind classes directly in components
-- Add new UI components to `src/shared/ui/`
+- グローバルスタイルは `src/styles/globals.css` を編集
+- コンポーネント内でTailwindクラスを直接変更
+- 新しいUIコンポーネントを `src/shared/ui/` に追加
 
-### Environment Configuration
+### 環境設定
 
-- Add new environment variables to `src/shared/lib/env.ts`
-- Add new constants to `src/shared/config.ts`
+- 新しい環境変数を `src/shared/lib/env.ts` に追加
+- 新しい定数を `src/shared/config.ts` に追加
 
-## 🆘 Troubleshooting
+## 🆘 トラブルシューティング
 
-### Common Issues
+### よくある問題
 
-**TypeScript errors about missing types:**
+**型が見つからないというTypeScriptエラー:**
 
-- Make sure you've generated Supabase types: `npx supabase gen types...`
-- Check that all imports use the correct paths
+- Supabase型を生成していることを確認：`npx supabase gen types...`
+- すべてのインポートが正しいパスを使用していることを確認
 
-**Supabase connection issues:**
+**Supabase接続の問題:**
 
-- Verify your `.env.local` file has the correct credentials
-- Check that your Supabase project is running
-- Ensure RLS policies are set up correctly
+- `.env.local` ファイルに正しい認証情報があることを確認
+- Supabaseプロジェクトが実行されていることを確認
+- RLSポリシーが正しく設定されていることを確認
 
-**Build errors:**
+**ビルドエラー:**
 
-- Run `npm run typecheck` to find type issues
-- Run `npm run lint` to find code style issues
+- `npm run typecheck` を実行して型の問題を確認
+- `npm run lint` を実行してコードスタイルの問題を確認
 
-## 📖 Further Reading
+## 📖 参考資料
 
 - [Vibe Coding concept by Andrej Karpathy](https://twitter.com/karpathy)
 - [Supabase Documentation](https://supabase.com/docs)
 - [React Query Documentation](https://tanstack.com/query)
 - [Tailwind CSS Documentation](https://tailwindcss.com/docs)
 
-## 🤝 Contributing
+## 🤝 貢献
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines and coding standards.
+開発ガイドラインとコーディング規約については [CONTRIBUTING.md](./CONTRIBUTING.md) を参照してください。
 
 ---
 
 **Happy Vibe Coding! 🎉**
 
-Start by describing what you want to build, then let AI help you implement it step by step.
+作りたいものを説明することから始めて、AIに実装をステップバイステップでサポートしてもらいましょう。

--- a/src/features/todo/components/TodoFilterBar.tsx
+++ b/src/features/todo/components/TodoFilterBar.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { Button } from '@/shared/ui';
+import { cn } from '@/shared/lib/utils';
+
+import type { TodoFilter } from '../types';
+
+interface TodoFilterBarProps {
+  activeFilter: TodoFilter;
+  onFilterChange: (nextFilter: TodoFilter) => void;
+  counts: {
+    total: number;
+    active: number;
+    completed: number;
+  };
+}
+
+const FILTER_OPTIONS: Array<{
+  value: TodoFilter;
+  label: string;
+  countKey: keyof TodoFilterBarProps['counts'];
+}> = [
+  { value: 'all', label: 'すべて', countKey: 'total' },
+  { value: 'active', label: '未完了', countKey: 'active' },
+  { value: 'completed', label: '完了', countKey: 'completed' },
+];
+
+/**
+ * Todo filter bar
+ *
+ * Provides quick filters for switching between all, active, and completed todos.
+ */
+export function TodoFilterBar({ activeFilter, onFilterChange, counts }: TodoFilterBarProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {FILTER_OPTIONS.map((option) => {
+        const isActive = option.value === activeFilter;
+        const badgeClassName = cn(
+          'ml-2 rounded-full px-2 py-0.5 text-xs font-semibold',
+          isActive ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600',
+        );
+
+        return (
+          <Button
+            key={option.value}
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-pressed={isActive}
+            onClick={() => onFilterChange(option.value)}
+            className={cn(
+              'flex items-center gap-2',
+              isActive && 'border-blue-300 bg-blue-50 text-blue-700 shadow-sm hover:bg-blue-100',
+            )}
+          >
+            <span>{option.label}</span>
+            <span className={badgeClassName}>{counts[option.countKey]}</span>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/todo/components/TodoFilterBar.tsx
+++ b/src/features/todo/components/TodoFilterBar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { Button } from '@/shared/ui';
+import { Search } from 'lucide-react';
+
+import { Button, Input } from '@/shared/ui';
 import { cn } from '@/shared/lib/utils';
 
 import type { TodoFilter } from '../types';
@@ -13,6 +15,8 @@ interface TodoFilterBarProps {
     active: number;
     completed: number;
   };
+  searchTerm: string;
+  onSearchChange: (nextSearchTerm: string) => void;
 }
 
 const FILTER_OPTIONS: Array<{
@@ -30,34 +34,57 @@ const FILTER_OPTIONS: Array<{
  *
  * Provides quick filters for switching between all, active, and completed todos.
  */
-export function TodoFilterBar({ activeFilter, onFilterChange, counts }: TodoFilterBarProps) {
+export function TodoFilterBar({
+  activeFilter,
+  onFilterChange,
+  counts,
+  searchTerm,
+  onSearchChange,
+}: TodoFilterBarProps) {
   return (
-    <div className="flex flex-wrap gap-2">
-      {FILTER_OPTIONS.map((option) => {
-        const isActive = option.value === activeFilter;
-        const badgeClassName = cn(
-          'ml-2 rounded-full px-2 py-0.5 text-xs font-semibold',
-          isActive ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600',
-        );
+    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div className="flex flex-wrap gap-2">
+        {FILTER_OPTIONS.map((option) => {
+          const isActive = option.value === activeFilter;
+          const badgeClassName = cn(
+            'ml-2 rounded-full px-2 py-0.5 text-xs font-semibold',
+            isActive ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600',
+          );
 
-        return (
-          <Button
-            key={option.value}
-            type="button"
-            variant="outline"
-            size="sm"
-            aria-pressed={isActive}
-            onClick={() => onFilterChange(option.value)}
-            className={cn(
-              'flex items-center gap-2',
-              isActive && 'border-blue-300 bg-blue-50 text-blue-700 shadow-sm hover:bg-blue-100',
-            )}
-          >
-            <span>{option.label}</span>
-            <span className={badgeClassName}>{counts[option.countKey]}</span>
-          </Button>
-        );
-      })}
+          return (
+            <Button
+              key={option.value}
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-pressed={isActive}
+              onClick={() => onFilterChange(option.value)}
+              className={cn(
+                'flex items-center gap-2',
+                isActive && 'border-blue-300 bg-blue-50 text-blue-700 shadow-sm hover:bg-blue-100',
+              )}
+            >
+              <span>{option.label}</span>
+              <span className={badgeClassName}>{counts[option.countKey]}</span>
+            </Button>
+          );
+        })}
+      </div>
+
+      <div className="relative w-full md:w-64">
+        <Search
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          aria-hidden
+        />
+        <Input
+          type="search"
+          value={searchTerm}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="キーワードで絞り込み"
+          className="pl-9 text-sm"
+          aria-label="Todo検索"
+        />
+      </div>
     </div>
   );
 }

--- a/src/features/todo/components/TodoList.tsx
+++ b/src/features/todo/components/TodoList.tsx
@@ -3,8 +3,10 @@ import { CheckCircle2, Trash2 } from 'lucide-react';
 
 import { Button } from '@/shared/ui';
 
-import { useTodos, useDeleteCompletedTodos } from '../hooks';
+import { useTodos, useDeleteCompletedTodos, useTodoFilters } from '../hooks';
 import { TodoItem } from './TodoItem';
+import { TodoFilterBar } from './TodoFilterBar';
+import { TodoSummary } from './TodoSummary';
 
 /**
  * Todo list component
@@ -14,8 +16,8 @@ import { TodoItem } from './TodoItem';
 export function TodoList() {
   const { data: todos, isLoading, error } = useTodos();
   const deleteCompleted = useDeleteCompletedTodos();
-
-  const completedCount = todos?.filter((todo) => todo.completed).length ?? 0;
+  const { filter, setFilter, filteredTodos, filteredCount, statistics } = useTodoFilters(todos);
+  const { totalCount, completedCount, activeCount, completionRate } = statistics;
 
   if (isLoading) {
     return (
@@ -53,13 +55,41 @@ export function TodoList() {
   }
 
   return (
-    <div className="space-y-3">
-      {todos.map((todo) => (
-        <TodoItem key={todo.id} todo={todo} />
-      ))}
+    <div className="space-y-4">
+      <TodoSummary
+        totalCount={totalCount}
+        completedCount={completedCount}
+        activeCount={activeCount}
+        completionRate={completionRate}
+      />
 
-      <div className="mt-6 space-y-3 text-center">
-        <p className="text-sm text-gray-500">合計 {todos.length} 件のTodo</p>
+      <TodoFilterBar
+        activeFilter={filter}
+        onFilterChange={(nextFilter) => setFilter(nextFilter)}
+        counts={{
+          total: totalCount,
+          active: activeCount,
+          completed: completedCount,
+        }}
+      />
+
+      {filteredCount === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center">
+          <h3 className="text-sm font-medium text-gray-900">該当するTodoがありません</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            別のフィルタを試すか、新しいTodoを追加してください。
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filteredTodos.map((todo) => (
+            <TodoItem key={todo.id} todo={todo} />
+          ))}
+        </div>
+      )}
+
+      <div className="space-y-3 rounded-lg border border-gray-100 bg-gray-50 p-4 text-center">
+        <p className="text-sm text-gray-500">合計 {totalCount} 件のTodo</p>
 
         {completedCount > 0 && (
           <Button

--- a/src/features/todo/components/TodoList.tsx
+++ b/src/features/todo/components/TodoList.tsx
@@ -16,7 +16,8 @@ import { TodoSummary } from './TodoSummary';
 export function TodoList() {
   const { data: todos, isLoading, error } = useTodos();
   const deleteCompleted = useDeleteCompletedTodos();
-  const { filter, setFilter, filteredTodos, filteredCount, statistics } = useTodoFilters(todos);
+  const { filter, setFilter, searchTerm, setSearchTerm, filteredTodos, filteredCount, statistics } =
+    useTodoFilters(todos);
   const { totalCount, completedCount, activeCount, completionRate } = statistics;
 
   if (isLoading) {
@@ -71,13 +72,17 @@ export function TodoList() {
           active: activeCount,
           completed: completedCount,
         }}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
       />
 
       {filteredCount === 0 ? (
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center">
           <h3 className="text-sm font-medium text-gray-900">該当するTodoがありません</h3>
           <p className="mt-1 text-xs text-gray-500">
-            別のフィルタを試すか、新しいTodoを追加してください。
+            {searchTerm
+              ? '検索キーワードを変えるか、条件に合うTodoを追加してください。'
+              : '別のフィルタを試すか、新しいTodoを追加してください。'}
           </p>
         </div>
       ) : (

--- a/src/features/todo/components/TodoSummary.tsx
+++ b/src/features/todo/components/TodoSummary.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import type { TodoStatistics } from '../types';
+
+interface TodoSummaryProps extends TodoStatistics {}
+
+/**
+ * Todo summary card
+ *
+ * Highlights progress and counts for the current todo list.
+ */
+export function TodoSummary({
+  totalCount,
+  completedCount,
+  activeCount,
+  completionRate,
+}: TodoSummaryProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wider text-gray-500">完了率</p>
+        <p className="text-2xl font-semibold text-gray-900">{completionRate}%</p>
+      </div>
+
+      <div className="flex flex-1 flex-wrap justify-end gap-6 text-sm">
+        <SummaryItem label="合計" value={totalCount} />
+        <SummaryItem label="未完了" value={activeCount} />
+        <SummaryItem label="完了" value={completedCount} />
+      </div>
+    </div>
+  );
+}
+
+interface SummaryItemProps {
+  label: string;
+  value: number;
+}
+
+function SummaryItem({ label, value }: SummaryItemProps) {
+  return (
+    <div className="min-w-[80px] text-right">
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="text-lg font-medium text-gray-900">{value} 件</p>
+    </div>
+  );
+}

--- a/src/features/todo/components/index.ts
+++ b/src/features/todo/components/index.ts
@@ -7,3 +7,5 @@
 export { TodoForm } from './TodoForm';
 export { TodoItem } from './TodoItem';
 export { TodoList } from './TodoList';
+export { TodoFilterBar } from './TodoFilterBar';
+export { TodoSummary } from './TodoSummary';

--- a/src/features/todo/hooks.ts
+++ b/src/features/todo/hooks.ts
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { ui } from '@/shared/config';
@@ -5,6 +6,7 @@ import { ui } from '@/shared/config';
 import { addTodo, deleteTodo, deleteCompletedTodos, listTodos, updateTodo } from './api';
 
 import type { TodoInput, TodoUpdate } from './schema';
+import type { Todo, TodoFilter, TodoStatistics } from './types';
 
 /**
  * Todo React Query hooks
@@ -120,4 +122,47 @@ export function useDeleteCompletedTodos() {
       console.error('一括削除に失敗しました:', error);
     },
   });
+}
+
+/**
+ * Manage todo filtering state and derived statistics
+ */
+export function useTodoFilters(todos?: Todo[]) {
+  const [filter, setFilter] = useState<TodoFilter>('all');
+
+  const statistics = useMemo<TodoStatistics>(() => {
+    const source = todos ?? [];
+    const totalCount = source.length;
+    const completedCount = source.filter((todo) => todo.completed).length;
+    const activeCount = totalCount - completedCount;
+    const completionRate = totalCount === 0 ? 0 : Math.round((completedCount / totalCount) * 100);
+
+    return {
+      totalCount,
+      completedCount,
+      activeCount,
+      completionRate,
+    };
+  }, [todos]);
+
+  const filteredTodos = useMemo(() => {
+    const source = todos ?? [];
+
+    switch (filter) {
+      case 'active':
+        return source.filter((todo) => !todo.completed);
+      case 'completed':
+        return source.filter((todo) => todo.completed);
+      default:
+        return source;
+    }
+  }, [todos, filter]);
+
+  return {
+    filter,
+    setFilter,
+    filteredTodos,
+    statistics,
+    filteredCount: filteredTodos.length,
+  };
 }

--- a/src/features/todo/hooks.ts
+++ b/src/features/todo/hooks.ts
@@ -129,6 +129,7 @@ export function useDeleteCompletedTodos() {
  */
 export function useTodoFilters(todos?: Todo[]) {
   const [filter, setFilter] = useState<TodoFilter>('all');
+  const [searchTerm, setSearchTerm] = useState('');
 
   const statistics = useMemo<TodoStatistics>(() => {
     const source = todos ?? [];
@@ -147,20 +148,39 @@ export function useTodoFilters(todos?: Todo[]) {
 
   const filteredTodos = useMemo(() => {
     const source = todos ?? [];
+    const normalizedQuery = searchTerm.trim().toLowerCase();
 
-    switch (filter) {
-      case 'active':
-        return source.filter((todo) => !todo.completed);
-      case 'completed':
-        return source.filter((todo) => todo.completed);
-      default:
-        return source;
+    const filteredByStatus = (() => {
+      switch (filter) {
+        case 'active':
+          return source.filter((todo) => !todo.completed);
+        case 'completed':
+          return source.filter((todo) => todo.completed);
+        default:
+          return source;
+      }
+    })();
+
+    if (!normalizedQuery) {
+      return filteredByStatus;
     }
-  }, [todos, filter]);
+
+    return filteredByStatus.filter((todo) => {
+      const title = todo.title?.toLowerCase() ?? '';
+      const description =
+        'description' in todo && typeof todo.description === 'string'
+          ? todo.description.toLowerCase()
+          : '';
+
+      return title.includes(normalizedQuery) || description.includes(normalizedQuery);
+    });
+  }, [todos, filter, searchTerm]);
 
   return {
     filter,
     setFilter,
+    searchTerm,
+    setSearchTerm,
     filteredTodos,
     statistics,
     filteredCount: filteredTodos.length,

--- a/src/features/todo/types.ts
+++ b/src/features/todo/types.ts
@@ -25,3 +25,12 @@ export interface TodoFormState {
   isSubmitting: boolean;
   error: string | null;
 }
+
+export type TodoFilter = 'all' | 'active' | 'completed';
+
+export interface TodoStatistics {
+  totalCount: number;
+  completedCount: number;
+  activeCount: number;
+  completionRate: number;
+}


### PR DESCRIPTION
# 概要
- Todo一覧にフィルタバーを追加し、完了・未完了・すべてを切り替え可能にしました。
- Todo統計カードを実装し、合計件数や完了率を即座に把握できるようにしました。
- `useTodoFilters` フックでフィルタリングと統計計算を集約しました。

# 動作確認
- npm run lint
- npm run typecheck
