### PR TITLE
feat: add todo filters, summary, and search

### DIFF
--- a/src/features/todo/components/TodoFilterBar.tsx
+++ b/src/features/todo/components/TodoFilterBar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { Button } from '@/shared/ui';
+import { Search } from 'lucide-react';
+
+import { Button, Input } from '@/shared/ui';
 import { cn } from '@/shared/lib/utils';
 
 import type { TodoFilter } from '../types';
@@ -13,6 +15,8 @@ interface TodoFilterBarProps {
     active: number;
     completed: number;
   };
+  searchTerm: string;
+  onSearchChange: (nextSearchTerm: string) => void;
 }
 
 const FILTER_OPTIONS: Array<{
@@ -30,34 +34,57 @@ const FILTER_OPTIONS: Array<{
  *
  * Provides quick filters for switching between all, active, and completed todos.
  */
-export function TodoFilterBar({ activeFilter, onFilterChange, counts }: TodoFilterBarProps) {
+export function TodoFilterBar({
+  activeFilter,
+  onFilterChange,
+  counts,
+  searchTerm,
+  onSearchChange,
+}: TodoFilterBarProps) {
   return (
-    <div className="flex flex-wrap gap-2">
-      {FILTER_OPTIONS.map((option) => {
-        const isActive = option.value === activeFilter;
-        const badgeClassName = cn(
-          'ml-2 rounded-full px-2 py-0.5 text-xs font-semibold',
-          isActive ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600',
-        );
+    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div className="flex flex-wrap gap-2">
+        {FILTER_OPTIONS.map((option) => {
+          const isActive = option.value === activeFilter;
+          const badgeClassName = cn(
+            'ml-2 rounded-full px-2 py-0.5 text-xs font-semibold',
+            isActive ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600',
+          );
 
-        return (
-          <Button
-            key={option.value}
-            type="button"
-            variant="outline"
-            size="sm"
-            aria-pressed={isActive}
-            onClick={() => onFilterChange(option.value)}
-            className={cn(
-              'flex items-center gap-2',
-              isActive && 'border-blue-300 bg-blue-50 text-blue-700 shadow-sm hover:bg-blue-100',
-            )}
-          >
-            <span>{option.label}</span>
-            <span className={badgeClassName}>{counts[option.countKey]}</span>
-          </Button>
-        );
-      })}
+          return (
+            <Button
+              key={option.value}
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-pressed={isActive}
+              onClick={() => onFilterChange(option.value)}
+              className={cn(
+                'flex items-center gap-2',
+                isActive && 'border-blue-300 bg-blue-50 text-blue-700 shadow-sm hover:bg-blue-100',
+              )}
+            >
+              <span>{option.label}</span>
+              <span className={badgeClassName}>{counts[option.countKey]}</span>
+            </Button>
+          );
+        })}
+      </div>
+
+      <div className="relative w-full md:w-64">
+        <Search
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          aria-hidden
+        />
+        <Input
+          type="search"
+          value={searchTerm}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="キーワードで絞り込み"
+          className="pl-9 text-sm"
+          aria-label="Todo検索"
+        />
+      </div>
     </div>
   );
 }

--- a/src/features/todo/components/TodoList.tsx
+++ b/src/features/todo/components/TodoList.tsx
@@ -16,7 +16,8 @@ import { TodoSummary } from './TodoSummary';
 export function TodoList() {
   const { data: todos, isLoading, error } = useTodos();
   const deleteCompleted = useDeleteCompletedTodos();
-  const { filter, setFilter, filteredTodos, filteredCount, statistics } = useTodoFilters(todos);
+  const { filter, setFilter, searchTerm, setSearchTerm, filteredTodos, filteredCount, statistics } =
+    useTodoFilters(todos);
   const { totalCount, completedCount, activeCount, completionRate } = statistics;
 
   if (isLoading) {
@@ -71,13 +72,17 @@ export function TodoList() {
           active: activeCount,
           completed: completedCount,
         }}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
       />
 
       {filteredCount === 0 ? (
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center">
           <h3 className="text-sm font-medium text-gray-900">該当するTodoがありません</h3>
           <p className="mt-1 text-xs text-gray-500">
-            別のフィルタを試すか、新しいTodoを追加してください。
+            {searchTerm
+              ? '検索キーワードを変えるか、条件に合うTodoを追加してください。'
+              : '別のフィルタを試すか、新しいTodoを追加してください。'}
           </p>
         </div>
       ) : (

--- a/src/features/todo/hooks.ts
+++ b/src/features/todo/hooks.ts
@@ -129,6 +129,7 @@ export function useDeleteCompletedTodos() {
  */
 export function useTodoFilters(todos?: Todo[]) {
   const [filter, setFilter] = useState<TodoFilter>('all');
+  const [searchTerm, setSearchTerm] = useState('');
 
   const statistics = useMemo<TodoStatistics>(() => {
     const source = todos ?? [];
@@ -147,20 +148,39 @@ export function useTodoFilters(todos?: Todo[]) {
 
   const filteredTodos = useMemo(() => {
     const source = todos ?? [];
+    const normalizedQuery = searchTerm.trim().toLowerCase();
 
-    switch (filter) {
-      case 'active':
-        return source.filter((todo) => !todo.completed);
-      case 'completed':
-        return source.filter((todo) => todo.completed);
-      default:
-        return source;
+    const filteredByStatus = (() => {
+      switch (filter) {
+        case 'active':
+          return source.filter((todo) => !todo.completed);
+        case 'completed':
+          return source.filter((todo) => todo.completed);
+        default:
+          return source;
+      }
+    })();
+
+    if (!normalizedQuery) {
+      return filteredByStatus;
     }
-  }, [todos, filter]);
+
+    return filteredByStatus.filter((todo) => {
+      const title = todo.title?.toLowerCase() ?? '';
+      const description =
+        'description' in todo && typeof todo.description === 'string'
+          ? todo.description.toLowerCase()
+          : '';
+
+      return title.includes(normalizedQuery) || description.includes(normalizedQuery);
+    });
+  }, [todos, filter, searchTerm]);
 
   return {
     filter,
     setFilter,
+    searchTerm,
+    setSearchTerm,
     filteredTodos,
     statistics,
     filteredCount: filteredTodos.length,


### PR DESCRIPTION
# 概要
- Todo一覧にフィルタバーを追加し、完了・未完了・すべてを切り替え可能にしました。
- Todo統計カードを実装し、合計件数や完了率を即座に把握できるようにしました。
- `useTodoFilters` フックでフィルタリングと統計計算を集約しました。
- フィルタバーにキーワード検索入力を追加し、タイトルや説明を対象に素早く絞り込めるようにしました。

# 動作確認
- npm run lint
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68d8e9acb410832eb90a2abc47df8861